### PR TITLE
Use vendorHash instead of vendorSha256

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,5 +7,5 @@ with import nixpkgs { inherit system; };
 buildGoModule {
   name = "nixos-shell";
   src = ./.;
-  vendorSha256 = "0gjj1zn29vyx704y91g77zrs770y2rakksnn9dhg8r6na94njh5a";
+  vendorHash = "sha256-qkBpSVLWZPRgS9bqOVUWHpyj8z/nheQJON3vJOwPUj4=";
 }


### PR DESCRIPTION
Tried to build using Nixpkgs 24.11, but got:

    error: buildGoModule: Expect vendorHash instead of vendorSha256

Swapping out that attribute name (and using an appropriate SRI hash) seems to work.