### PR TITLE
Nix cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 pkg/*
 bin/*
+/result*

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,9 @@
 {
-  nixpkgs ? <nixpkgs>, system ? builtins.currentSystem
+  pkgs ? import nixpkgs { inherit system; },
+  nixpkgs ? <nixpkgs>,
+  system ? builtins.currentSystem
 }:
-
-with import nixpkgs { inherit system; };
-
-buildGoModule {
+pkgs.buildGoModule {
   name = "nixos-shell";
   src = ./.;
   vendorSha256 = "0gjj1zn29vyx704y91g77zrs770y2rakksnn9dhg8r6na94njh5a";

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/gza2bw1c2lz58qxxsdx6f79njwkpjshj-nixos-shell


### PR DESCRIPTION
 * Removes a `result` symlink that had crept in, and gitignores such top-level build artefacts.
 * Use a direct reference to `buildGoModule`, rather than `with`. The latter was not being used "statically" (i.e. it wasn't `with { ... }` or `with rec { ... }`), which prevents tools like linters from finding missing variables (and is generally seen as bad form these days).
 * Parameterise the Nixpkgs attrset (`pkgs`), so we don't have to `import` anything. This makes my life much easier, since (a) I use pinned Nixpkgs tarballs, rather than `<nixpkgs>`/`NIX_PATH`/channels/flakes/etc., (b) I mix-and-match definitions from many Nixpkgs versions for compability reasons, (c) I have complicated sets of overlays, etc. Hence it's much easier to just pass in whatever attrset I'm using, rather than having to e.g. generate a .nix file to use as the `nixpkgs` argument.